### PR TITLE
Test new pdf load

### DIFF
--- a/src/components/ArxivInput/ArxivInput.js
+++ b/src/components/ArxivInput/ArxivInput.js
@@ -107,10 +107,10 @@ const ArxivInput = ({ messages, setDocs, setMessages }) => {
         }
 
         // reset messages list if load was successful
-        if (data.result.type === "success" && messages.length > 0) {
+        if (data.result.type === "success") {
             setMessages([
                 {
-                    text: "Hey! Ask a question :)",
+                    text: "Ask a question about the paper :)",
                     type: "response",
                 },
             ]);

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -10,12 +10,16 @@ const Footer = () => {
         <div className={styles.footer}>
             <div className={styles.footer_text}>
                 <p className={inter.className}>
-                    Built by{" "}
+                    Made by{" "}
                     <Link href="https://www.linkedin.com/in/nathanclairmonte/" target="_blank">
                         Nathan Clairmonte
                     </Link>
                     . Powered by{" "}
-                    <Link href="https://github.com/hwchase17/langchain" target="_blank">
+                    <Link href="https://nextjs.org/" target="_blank">
+                        Next.js
+                    </Link>{" "}
+                    and{" "}
+                    <Link href="https://langchain.com/" target="_blank">
                         LangChain
                     </Link>
                     .

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -13,12 +13,8 @@ const Navbar = ({ apiKey, setApiKey }) => {
                 </Link>
             </div>
             <input
-                // disabled={loading}
-                // onKeyDown={handleEnterKeyPress}
-                // ref={textAreaRef}
                 autoFocus={false}
                 rows={1}
-                // maxLength={512}
                 type="password"
                 id="apiKey"
                 name="apiKey"
@@ -35,13 +31,13 @@ const Navbar = ({ apiKey, setApiKey }) => {
                 >
                     Repo
                 </Link>
-                <Link
+                {/* <Link
                     className={inter.className}
                     href="https://github.com/nathanclairmonte"
                     target="_blank"
                 >
-                    Nathan's Github
-                </Link>
+                    My Github
+                </Link> */}
             </div>
         </div>
     );

--- a/src/components/Navbar/Navbar.module.css
+++ b/src/components/Navbar/Navbar.module.css
@@ -8,7 +8,7 @@
 }
 
 .nav_container a {
-    color: snow;
+    color: #eb9722;
     font-weight: 400;
 }
 
@@ -24,14 +24,15 @@
 .nav_links {
     width: 16rem;
     display: flex;
-    justify-content: space-evenly;
-    align-items: center;
+    justify-content: flex-end;
+    padding-right: 20px;
+    /* border: 1px solid white; */
 }
 
 .apikey_input {
     resize: none;
     font-size: 1.1rem;
-    padding: 1rem 2rem 1rem 2rem;
+    padding: 1rem;
     width: 42vw;
     height: 42px;
     max-width: 800px;

--- a/src/pages/api/query.js
+++ b/src/pages/api/query.js
@@ -53,7 +53,7 @@ export default async function handler(req, res) {
         return res.status(500).json({
             result: {
                 type: "error",
-                message: `${error} \n Have you entered your API key?`,
+                message: `${error}. \n Have you entered your API key?`,
             },
         });
     }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,8 +21,10 @@ export default function Home() {
 
     // auto scroll chat to bottom
     useEffect(() => {
-        const messageList = messageListRef.current;
-        messageList.scrollTop = messageList.scrollHeight;
+        if (messages.length > 0) {
+            const messageList = messageListRef.current;
+            messageList.scrollTop = messageList.scrollHeight;
+        }
     }, [messages]);
 
     // focus on text input whenever messages state changes

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,17 +19,23 @@ export default function Home() {
     const messageListRef = useRef(null);
     const textAreaRef = useRef(null);
 
-    // auto scroll chat to bottom
+    // auto scroll chat to bottom whenever messages state changes
     useEffect(() => {
-        if (messages.length > 0) {
+        if (messages.length > -1) {
             const messageList = messageListRef.current;
-            messageList.scrollTop = messageList.scrollHeight;
-        }
-    }, [messages]);
 
-    // focus on text input whenever messages state changes
-    useEffect(() => {
-        textAreaRef.current.focus();
+            // save current window scroll position
+            const prevWinScrollY = window.scrollY;
+
+            // scroll chat to bottom
+            messageList.scrollTop = messageList.scrollHeight;
+
+            // refocus on the text input
+            textAreaRef.current.focus();
+
+            // restore window scroll position
+            window.scrollTo(0, prevWinScrollY);
+        }
     }, [messages]);
 
     // ensure that history keeps up to date and never exceeds 2 messages


### PR DESCRIPTION
# Fixed PDF Loading Issue

To give an overview, the issue was that my chosen PDF loading method was unable to work when in production. Here's why:

My original PDF loading method was to fetch the PDF from the ArXiv website and save it locally in a papers folder as `papers/paper.pdf` before loading it with LangChain's `PDFLoader` class. This worked when running locally, because the application had access to write to the filesystem.

However, when deployed in production, Vercel's serverless functions apparently only operate in read-only mode. This meant that we could no longer save the PDF to `papers/paper.pdf`, leading to an error when LangChain tried to load it.

To solve this, I first tried just passing the ArXiv link to `PDFLoader` directly, but this led to an error because it was searching my local filesystem for the link. Did some digging and realised that this was happening because `PDFLoader` uses `readFile()` from `node:fs/promises`. This function is only designed for loading files from the local filesystem or from blob, and is unable to load from a web URL.

Finally, I solved the problem by first fetching the PDF from the website and then storing it as a BLOB (Binary Large Object), which then gets passed to the `PDFLoader`. This works both locally and in production! Yay :)